### PR TITLE
Add CriteriaRepository trait for Nextras ORM integration

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,6 +6,7 @@ Criteria pattern for [Nextras ORM](https://nextras.org/orm), inspired by [Doctri
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Repository Integration](#repository-integration)
 - [Expression Builder](#expression-builder)
 - [Ordering](#ordering)
 - [Pagination](#pagination)
@@ -77,6 +78,53 @@ class UserRepository
             ->fetchAll();
     }
 }
+```
+
+## Repository Integration
+
+Use the `CriteriaRepository` to add criteria support directly to your Nextras ORM repositories.
+
+```php
+use Contributte\Criteria\Nextras\CriteriaRepository;
+use Nextras\Orm\Repository\Repository;
+
+class UserRepository extends Repository
+{
+    use CriteriaRepository;
+
+    public static function getEntityClassNames(): array
+    {
+        return [User::class];
+    }
+}
+```
+
+The trait provides the following methods:
+
+- `findByCriteria(Criteria $criteria): ICollection` - returns a filtered collection
+- `getByCriteria(Criteria $criteria): ?IEntity` - returns a single entity or null
+- `getByCriteriaChecked(Criteria $criteria): IEntity` - returns a single entity or throws
+
+```php
+use Contributte\Criteria\Criteria;
+use Contributte\Criteria\Ordering;
+
+// Find all active adults
+$criteria = Criteria::create()
+    ->where(Criteria::expr()->andX(
+        Criteria::expr()->eq('status', 'active'),
+        Criteria::expr()->gte('age', 18),
+    ))
+    ->orderBy(Ordering::desc('createdAt'))
+    ->setMaxResults(10);
+
+$users = $userRepository->findByCriteria($criteria)->fetchAll();
+
+// Get a single entity
+$criteria = Criteria::create()
+    ->where(Criteria::expr()->eq('email', 'admin@example.com'));
+
+$user = $userRepository->getByCriteria($criteria);
 ```
 
 ## Expression Builder

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,5 @@ parameters:
 		- php
 	paths:
 		- src
+	ignoreErrors:
+		- identifier: trait.unused

--- a/src/Nextras/CriteriaRepository.php
+++ b/src/Nextras/CriteriaRepository.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Criteria\Nextras;
+
+use Contributte\Criteria\Criteria;
+use Nextras\Orm\Collection\ICollection;
+use Nextras\Orm\Entity\IEntity;
+use Nextras\Orm\Repository\Repository;
+
+/**
+ * Trait for Nextras ORM repositories to add criteria-based querying.
+ *
+ * Use this trait in your repository classes that extend Nextras\Orm\Repository\Repository.
+ *
+ * @phpstan-require-extends Repository
+ * @template TEntity of IEntity
+ */
+trait CriteriaRepository
+{
+
+	private ?CriteriaApplicator $criteriaApplicator = null;
+
+	/**
+	 * Sets a custom criteria applicator.
+	 */
+	public function setCriteriaApplicator(CriteriaApplicator $applicator): void
+	{
+		$this->criteriaApplicator = $applicator;
+	}
+
+	/**
+	 * Finds entities matching the given criteria.
+	 *
+	 * @return ICollection<TEntity>
+	 */
+	public function findByCriteria(Criteria $criteria): ICollection
+	{
+		/** @var ICollection<TEntity> $collection */
+		$collection = $this->findAll();
+
+		return $this->getCriteriaApplicator()->apply($collection, $criteria);
+	}
+
+	/**
+	 * Finds a single entity matching the given criteria, or null.
+	 *
+	 * @return TEntity|null
+	 */
+	public function getByCriteria(Criteria $criteria): ?IEntity
+	{
+		return $this->findByCriteria($criteria)->fetch();
+	}
+
+	/**
+	 * Finds a single entity matching the given criteria, or throws.
+	 *
+	 * @return TEntity
+	 */
+	public function getByCriteriaChecked(Criteria $criteria): IEntity
+	{
+		return $this->findByCriteria($criteria)->fetchChecked();
+	}
+
+	/**
+	 * Returns the criteria applicator instance.
+	 */
+	private function getCriteriaApplicator(): CriteriaApplicator
+	{
+		if ($this->criteriaApplicator === null) {
+			$this->criteriaApplicator = new CriteriaApplicator();
+		}
+
+		return $this->criteriaApplicator;
+	}
+
+}

--- a/tests/Cases/Unit/Nextras/CriteriaRepositoryTest.phpt
+++ b/tests/Cases/Unit/Nextras/CriteriaRepositoryTest.phpt
@@ -1,0 +1,264 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Unit\Nextras;
+
+use Contributte\Criteria\Criteria;
+use Contributte\Criteria\Nextras\CriteriaApplicator;
+use Contributte\Criteria\Nextras\CriteriaRepository;
+use Contributte\Criteria\Ordering;
+use Contributte\Tester\Toolkit;
+use Nextras\Orm\Collection\ICollection;
+use Nextras\Orm\Entity\IEntity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+/**
+ * @implements ICollection<IEntity>
+ */
+class StubCollection implements ICollection
+{
+
+	/** @var array<mixed> */
+	public array $findByCalls = [];
+
+	/** @var array<mixed> */
+	public array $orderByCalls = [];
+
+	/** @var array<mixed> */
+	public array $limitByCalls = [];
+
+	public function findBy(array $conds): ICollection
+	{
+		$this->findByCalls[] = $conds;
+
+		return $this;
+	}
+
+	public function getBy(array $conds): ?IEntity
+	{
+		return null;
+	}
+
+	public function getByChecked(array $conds): IEntity
+	{
+		throw new \Nextras\Orm\Exception\NoResultException();
+	}
+
+	public function getById($id): ?IEntity
+	{
+		return null;
+	}
+
+	public function getByIdChecked($id): IEntity
+	{
+		throw new \Nextras\Orm\Exception\NoResultException();
+	}
+
+	public function orderBy($expression, string $direction = self::ASC): ICollection
+	{
+		$this->orderByCalls[] = [$expression, $direction];
+
+		return $this;
+	}
+
+	public function resetOrderBy(): ICollection
+	{
+		return $this;
+	}
+
+	public function limitBy(int $limit, int|null $offset = null): ICollection
+	{
+		$this->limitByCalls[] = [$limit, $offset];
+
+		return $this;
+	}
+
+	public function fetch(): ?IEntity
+	{
+		return null;
+	}
+
+	public function fetchChecked(): IEntity
+	{
+		throw new \Nextras\Orm\Exception\NoResultException();
+	}
+
+	public function fetchAll(): array
+	{
+		return [];
+	}
+
+	public function fetchPairs(string|null $key = null, string|null $value = null): array
+	{
+		return [];
+	}
+
+	public function getIterator(): \Iterator
+	{
+		return new \ArrayIterator([]);
+	}
+
+	public function toMemoryCollection(): \Nextras\Orm\Collection\MemoryCollection
+	{
+		throw new \LogicException('Not implemented');
+	}
+
+	public function setRelationshipMapper(\Nextras\Orm\Mapper\IRelationshipMapper|null $mapper): ICollection
+	{
+		return $this;
+	}
+
+	public function getRelationshipMapper(): ?\Nextras\Orm\Mapper\IRelationshipMapper
+	{
+		return null;
+	}
+
+	public function setRelationshipParent(IEntity $parent): ICollection
+	{
+		return $this;
+	}
+
+	public function countStored(): int
+	{
+		return 0;
+	}
+
+	public function count(): int
+	{
+		return 0;
+	}
+
+	public function subscribeOnEntityFetch(callable $callback): void
+	{
+	}
+
+}
+
+class StubRepository
+{
+
+	/** @use CriteriaRepository<IEntity> */
+	use CriteriaRepository;
+
+	private StubCollection $collection;
+
+	public function __construct()
+	{
+		$this->collection = new StubCollection();
+	}
+
+	/** @return ICollection<IEntity> */
+	public function findAll(): ICollection
+	{
+		return $this->collection;
+	}
+
+	public function getCollection(): StubCollection
+	{
+		return $this->collection;
+	}
+
+}
+
+// findByCriteria returns ICollection
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create();
+
+	$result = $repository->findByCriteria($criteria);
+
+	Assert::type(ICollection::class, $result);
+});
+
+// findByCriteria applies where expression
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->where(Criteria::expr()->eq('status', 'active'));
+
+	$repository->findByCriteria($criteria);
+
+	Assert::count(1, $repository->getCollection()->findByCalls);
+	Assert::same(['status' => 'active'], $repository->getCollection()->findByCalls[0]);
+});
+
+// findByCriteria applies ordering
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->orderBy(Ordering::desc('createdAt'));
+
+	$repository->findByCriteria($criteria);
+
+	Assert::count(1, $repository->getCollection()->orderByCalls);
+	Assert::same('createdAt', $repository->getCollection()->orderByCalls[0][0]);
+	Assert::same(ICollection::DESC, $repository->getCollection()->orderByCalls[0][1]);
+});
+
+// findByCriteria applies pagination
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->setFirstResult(10)
+		->setMaxResults(25);
+
+	$repository->findByCriteria($criteria);
+
+	Assert::count(1, $repository->getCollection()->limitByCalls);
+	Assert::same(25, $repository->getCollection()->limitByCalls[0][0]);
+	Assert::same(10, $repository->getCollection()->limitByCalls[0][1]);
+});
+
+// getByCriteria returns null when no entity found
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->where(Criteria::expr()->eq('id', 999));
+
+	$result = $repository->getByCriteria($criteria);
+
+	Assert::null($result);
+});
+
+// getByCriteriaChecked throws when no entity found
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->where(Criteria::expr()->eq('id', 999));
+
+	Assert::exception(
+		fn () => $repository->getByCriteriaChecked($criteria),
+		\Nextras\Orm\Exception\NoResultException::class,
+	);
+});
+
+// setCriteriaApplicator allows custom applicator
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$applicator = new CriteriaApplicator();
+
+	$repository->setCriteriaApplicator($applicator);
+
+	$criteria = Criteria::create();
+	$result = $repository->findByCriteria($criteria);
+
+	Assert::type(ICollection::class, $result);
+});
+
+// findByCriteria with full criteria (where + ordering + pagination)
+Toolkit::test(function (): void {
+	$repository = new StubRepository();
+	$criteria = Criteria::create()
+		->where(Criteria::expr()->eq('status', 'active'))
+		->orderBy(Ordering::desc('createdAt'))
+		->setFirstResult(0)
+		->setMaxResults(10);
+
+	$result = $repository->findByCriteria($criteria);
+
+	Assert::type(ICollection::class, $result);
+	Assert::count(1, $repository->getCollection()->findByCalls);
+	Assert::count(1, $repository->getCollection()->orderByCalls);
+	Assert::count(1, $repository->getCollection()->limitByCalls);
+});


### PR DESCRIPTION
## Summary
This PR introduces a `CriteriaRepository` trait that seamlessly integrates the Criteria pattern with Nextras ORM repositories, allowing developers to use criteria-based querying directly on their repository classes.

## Key Changes
- **New `CriteriaRepository` trait** (`src/Nextras/CriteriaRepository.php`):
  - Provides three public methods: `findByCriteria()`, `getByCriteria()`, and `getByCriteriaChecked()`
  - Supports filtering, ordering, and pagination through the Criteria API
  - Allows custom `CriteriaApplicator` injection via `setCriteriaApplicator()`
  - Includes proper PHPStan generics support with `@template TEntity`

- **Comprehensive test suite** (`tests/Cases/Unit/Nextras/CriteriaRepositoryTest.phpt`):
  - Tests all three query methods
  - Validates criteria application (where, ordering, pagination)
  - Tests null/exception handling for single entity queries
  - Verifies custom applicator injection

- **Documentation updates** (`.docs/README.md`):
  - Added new "Repository Integration" section with usage examples
  - Demonstrates how to use the trait in repository classes
  - Shows practical examples of filtering, ordering, and pagination

- **PHPStan configuration** (`phpstan.neon`):
  - Added `trait.unused` to ignored errors to suppress false positives for trait usage

## Implementation Details
The trait leverages the existing `CriteriaApplicator` to apply criteria transformations to Nextras ORM collections. It follows the repository pattern conventions and maintains type safety through PHPStan generics.

https://claude.ai/code/session_01EHcTJHnaqNJYYGnNtg1isK